### PR TITLE
IMS #287145 VirutalRouter Failure 검증 이후 VirtualRouter 기동 시 특정 노드의 networkdaemon이 CrashLoopBackOff 에러가 발생하며 재기동을 반복하는 현상

### DIFF
--- a/internal/daemon/netlink/netlink.go
+++ b/internal/daemon/netlink/netlink.go
@@ -749,6 +749,12 @@ func SetInterface2Container(containerPid int, interfaceName string, isInternal b
 
 	// if link, peerLink, err := SetVethInterface(rootNetlinkHandle, newinterfaceName); err != nil {
 	if link, err := setLink(rootNetlinkHandle, veth); err != nil {
+		if veth.PeerName[:3] == "eth" {
+			if err := clearLink(rootNetlinkHandle, veth.PeerName); err != nil {
+				klog.ErrorS(err, "ClearVethInterface is failed", "interfaceName", newinterfacePeerName)
+				return err
+			}
+		}
 		return err
 	} else {
 		vethIntf = link


### PR DESCRIPTION
IMS #287145 VirutalRouter Failure 검증 이후 VirtualRouter 기동 시 특정 노드의 networkdaemon이 CrashLoopBackOff 에러가 발생하며 재기동을 반복하는 현상
 (problem)
veth인터페이스 중 bridge와 접합이 되지 않은 채 peer interface가 ethint와 같이 남아 있을경우 발생